### PR TITLE
Include "unidentified developer" warning in installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ In comparison (macOS):
 
 By proceeding with use of the bundle, you understand that the parts of the bundle are governed by their separate license agreements, and do not form a single product ([more info](src/main/resources/BundleAgreement.html)).
 
+
 ## Install the Bundle
 
 1. After downloaded the bundle, extract the archive.
@@ -52,28 +53,28 @@ By proceeding with use of the bundle, you understand that the parts of the bundl
  
  #### If you receive this message:
  
-  `" ... can't be opened because it is from an unidentified developer" `
+ > " ... can't be opened because it is from an unidentified developer" 
  
-> i. Go to **Security & Privacy** settings on your computer under **System Preferences**
-> ii. Choose to **Open Anyways** to allow it to run **From unidentified developer**
+- Go to **Security & Privacy** settings on your computer under **System Preferences**
+- Choose to **Open Anyways** to allow it to run **From unidentified developer**
  
  
-Alternatively, to override your security settings and open the app anyway:
+**Alternatively**, to override your security settings and open the app anyway:
  
-> i. In the Finder, locate the app you want to open. 
+- In the Finder, locate the app you want to open. 
     (Don’t use Launchpad to do this. Launchpad doesn’t allow you to access the shortcut menu.)
-> ii. Press the **Control** key, then click the app icon.
-> iii. Choose **Open** from the shortcut menu.
-> iv. Click **Open**.
+- Press the **Control** key, then click the app icon.
+- Choose **Open** from the shortcut menu.
+- Click **Open**.
  
  The app is saved as an exception to your security settings, and you will be able to open it in the future by double-clicking it, just like any registered app.
  
  #### If you receive this message:
   
-   `" The application is running in App Translocation, a macOS security mechanism for apps that are not properly installed. You cannot create permanent rules until you move the application to the Applications folder and launch it from there." `
+   >" The application is running in App Translocation, a macOS security mechanism for apps that are not properly installed. You cannot create permanent rules until you move the application to the Applications folder and launch it from there."
   
-> Simply move the bundle to a different directory.
-> To read more about **App Translocation**, please visit [here](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17).
+- Simply move the bundle to a different directory.
+- To read more about **App Translocation**, please visit [here](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17).
   
   
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ By proceeding with use of the bundle, you understand that the parts of the bundl
  This bundle is currently not registered as an identified developer with the Mac Store.
   To use the bundle, you must override the **Security & Privacy** settings. 
  
- If you receive this message:
+ #### If you receive this message:
  
   `" ... can't be opened because it is from an unidentified developer" `
  
@@ -67,11 +67,12 @@ Go to **Security & Privacy** settings on your computer under **System Preference
  
  The app is saved as an exception to your security settings, and you will be able to open it in the future by double-clicking it, just like any registered app.
  
- > If you receive this message:
+ #### If you receive this message:
   
    `" The application is running in App Translocation, a macOS security mechanism for apps that are not properly installed. You cannot create permanent rules until you move the application to the Applications folder and launch it from there." `
   
-  Simply move the bundle to a different directory. To read more about **App Translocation**, please visit [here](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17).
+  Simply move the bundle to a different directory.
+  To read more about **App Translocation**, please visit [here](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17).
   
   
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,40 @@ In comparison (macOS):
 
 By proceeding with use of the bundle, you understand that the parts of the bundle are governed by their separate license agreements, and do not form a single product ([more info](src/main/resources/BundleAgreement.html)).
 
+## Install the Bundle
+
+1. After downloaded the bundle, extract the archive.
+2. Move the extracted directory to a location where you keep your projects (e.g., Documents/Projects)
+
+- For Mac Users:
+ This bundle is currently not registered as an identified developer with the Mac Store.
+  To use the bundle, you must override the **Security & Privacy** settings. 
+ 
+ If you receive this message:
+ 
+  `" ... can't be opened because it is from an unidentified developer" `
+ 
+ then go to **Security & Privacy** settings on your computer under **System Preferences** and choose to "Open Anyways" to allow it to run "From unidentified developer".
+ 
+ 
+ Alternatively, to override your security settings and open the app anyway:
+ 
+ 1. In the Finder, locate the app you want to open.
+ (Don’t use Launchpad to do this. Launchpad doesn’t allow you to access the shortcut menu.)
+ 2. Press the Control key, then click the app icon.
+ 3. Choose Open from the shortcut menu.
+ 4. Click Open.
+ 
+ The app is saved as an exception to your security settings, and you will be able to open it in the future by double-clicking it, just like any registered app.
+ 
+ If you receive this message:
+  
+   `" The application is running in App Translocation, a macOS security mechanism for apps that are not properly installed. You cannot create permanent rules until you move the application to the Applications folder and launch it from there." `
+  
+  Simply move the bundle to a different directory. To read more about **App Translocation**, please visit [here](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17).
+  
+  
+
 ## Build
 
 To create the bundle, invoke:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ By proceeding with use of the bundle, you understand that the parts of the bundl
 1. After downloaded the bundle, extract the archive.
 2. Move the extracted directory to a location where you keep your projects (e.g., Documents/Projects)
 
-- For Mac Users:
+> For Mac Users:
  This bundle is currently not registered as an identified developer with the Mac Store.
   To use the bundle, you must override the **Security & Privacy** settings. 
  
@@ -54,20 +54,20 @@ By proceeding with use of the bundle, you understand that the parts of the bundl
  
   `" ... can't be opened because it is from an unidentified developer" `
  
- then go to **Security & Privacy** settings on your computer under **System Preferences** and choose to "Open Anyways" to allow it to run "From unidentified developer".
+Go to **Security & Privacy** settings on your computer under **System Preferences** and choose to "Open Anyways" to allow it to run "From unidentified developer".
  
  
- Alternatively, to override your security settings and open the app anyway:
+> Alternatively, to override your security settings and open the app anyway:
  
  1. In the Finder, locate the app you want to open.
  (Don’t use Launchpad to do this. Launchpad doesn’t allow you to access the shortcut menu.)
- 2. Press the Control key, then click the app icon.
- 3. Choose Open from the shortcut menu.
- 4. Click Open.
+ 2. Press the **Control** key, then click the app icon.
+ 3. Choose **Open** from the shortcut menu.
+ 4. Click **Open**.
  
  The app is saved as an exception to your security settings, and you will be able to open it in the future by double-clicking it, just like any registered app.
  
- If you receive this message:
+ > If you receive this message:
   
    `" The application is running in App Translocation, a macOS security mechanism for apps that are not properly installed. You cannot create permanent rules until you move the application to the Applications folder and launch it from there." `
   

--- a/README.md
+++ b/README.md
@@ -54,16 +54,17 @@ By proceeding with use of the bundle, you understand that the parts of the bundl
  
   `" ... can't be opened because it is from an unidentified developer" `
  
-Go to **Security & Privacy** settings on your computer under **System Preferences** and choose to "Open Anyways" to allow it to run "From unidentified developer".
+> i. Go to **Security & Privacy** settings on your computer under **System Preferences**
+> ii. Choose to **Open Anyways** to allow it to run **From unidentified developer**
  
  
-> Alternatively, to override your security settings and open the app anyway:
+Alternatively, to override your security settings and open the app anyway:
  
- 1. In the Finder, locate the app you want to open.
- (Don’t use Launchpad to do this. Launchpad doesn’t allow you to access the shortcut menu.)
- 2. Press the **Control** key, then click the app icon.
- 3. Choose **Open** from the shortcut menu.
- 4. Click **Open**.
+> i. In the Finder, locate the app you want to open. 
+    (Don’t use Launchpad to do this. Launchpad doesn’t allow you to access the shortcut menu.)
+> ii. Press the **Control** key, then click the app icon.
+> iii. Choose **Open** from the shortcut menu.
+> iv. Click **Open**.
  
  The app is saved as an exception to your security settings, and you will be able to open it in the future by double-clicking it, just like any registered app.
  
@@ -71,8 +72,8 @@ Go to **Security & Privacy** settings on your computer under **System Preference
   
    `" The application is running in App Translocation, a macOS security mechanism for apps that are not properly installed. You cannot create permanent rules until you move the application to the Applications folder and launch it from there." `
   
-  Simply move the bundle to a different directory.
-  To read more about **App Translocation**, please visit [here](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17).
+> Simply move the bundle to a different directory.
+> To read more about **App Translocation**, please visit [here](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17).
   
   
 


### PR DESCRIPTION
For issue #2 

A temporary instruction before the bundle is signed.